### PR TITLE
functions for sed peaks

### DIFF
--- a/agnpy/compton.py
+++ b/agnpy/compton.py
@@ -237,6 +237,17 @@ class SynchrotronSelfCompton:
         sed = prefactor * self.com_sed_emissivity(epsilon_prime)
         return sed.to("erg cm-2 s-1")
 
+    def sed_peak_flux(nu):
+        """provided a grid of frequencies nu, returns the peak flux of the SED
+        """
+        return self.sed_flux(nu).max()
+
+    def sed_peak_nu(nu):
+        """provided a grid of frequencies nu, returns the frequency at which the SED peaks
+        """
+        idx_max = self.sed_flux(nu).argmax()
+        return nu[idx_max] 
+
 
 class ExternalCompton:
     """class for External Compton radiation computation
@@ -474,3 +485,14 @@ class ExternalCompton:
             return self._sed_flux_shell_blr(nu)
         if self.target.type == "RingDustTorus":
             return self._sed_flux_ring_torus(nu)
+
+    def sed_peak_flux(nu):
+        """provided a grid of frequencies nu, returns the peak flux of the SED
+        """
+        return self.sed_flux(nu).max()
+
+    def sed_peak_nu(nu):
+        """provided a grid of frequencies nu, returns the frequency at which the SED peaks
+        """
+        idx_max = self.sed_flux(nu).argmax()
+        return nu[idx_max] 

--- a/agnpy/compton.py
+++ b/agnpy/compton.py
@@ -246,7 +246,7 @@ class SynchrotronSelfCompton:
         """provided a grid of frequencies nu, returns the frequency at which the SED peaks
         """
         idx_max = self.sed_flux(nu).argmax()
-        return nu[idx_max] 
+        return nu[idx_max]
 
 
 class ExternalCompton:
@@ -495,4 +495,4 @@ class ExternalCompton:
         """provided a grid of frequencies nu, returns the frequency at which the SED peaks
         """
         idx_max = self.sed_flux(nu).argmax()
-        return nu[idx_max] 
+        return nu[idx_max]

--- a/agnpy/synchrotron.py
+++ b/agnpy/synchrotron.py
@@ -41,10 +41,10 @@ def nu_B(B):
 class Synchrotron:
     """Class for synchrotron radiation computation
 
-	Parameters
-	----------
-	blob : :class:`~agnpy.emission_region.Blob`
-		emitting region and electron distribution 
+    Parameters
+    ----------
+    blob : :class:`~agnpy.emission_region.Blob`
+        emitting region and electron distribution 
         
     ssa : bool
         whether or not to consider synchrotron self absorption (SSA).    
@@ -172,11 +172,11 @@ class Synchrotron:
 
         .. math::
             \\nu F_{\\nu} \, [\mathrm{erg}\,\mathrm{cm}^{-2}\,\mathrm{s}^{-1}]
-		
+
         Eq. 21 in [Finke2008]_.
 
-		Parameters
-		----------
+        Parameters
+        ----------
         nu : :class:`~astropy.units.Quantity`
             array of frequencies, in Hz, to compute the sed, **note** these are 
             observed frequencies (observer frame).
@@ -194,3 +194,14 @@ class Synchrotron:
         )
         sed = prefactor * self.com_sed_emissivity(epsilon_prime)
         return sed.to("erg cm-2 s-1")
+
+    def sed_peak_flux(nu):
+        """provided a grid of frequencies nu, returns the peak flux of the SED
+        """
+        return self.sed_flux(nu).max()
+
+    def sed_peak_nu(nu):
+        """provided a grid of frequencies nu, returns the frequency at which the SED peaks
+        """
+        idx_max = self.sed_flux(nu).argmax()
+        return nu[idx_max] 

--- a/agnpy/synchrotron.py
+++ b/agnpy/synchrotron.py
@@ -204,4 +204,4 @@ class Synchrotron:
         """provided a grid of frequencies nu, returns the frequency at which the SED peaks
         """
         idx_max = self.sed_flux(nu).argmax()
-        return nu[idx_max] 
+        return nu[idx_max]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,6 +64,7 @@ master_doc = "index"
 
 # dictionary with external packages references
 intersphinx_mapping = {
-    "numpy": ("https://docs.scipy.org/doc/numpy/", None),
+    "numpy": ("https://numpy.org", None),
     "astropy": ("http://docs.astropy.org/en/latest/", None),
+    "matplotlib": ("https://matplotlib.org", None)
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,5 +66,5 @@ master_doc = "index"
 intersphinx_mapping = {
     "numpy": ("https://numpy.org", None),
     "astropy": ("http://docs.astropy.org/en/latest/", None),
-    "matplotlib": ("https://matplotlib.org", None)
+    "matplotlib": ("https://matplotlib.org", None),
 }

--- a/tests/basic/test_gmax.py
+++ b/tests/basic/test_gmax.py
@@ -7,7 +7,7 @@ import astropy.constants as const
 from astropy.coordinates import Distance
 import matplotlib.pyplot as plt
 
-plt.ion()
+#plt.ion()
 import sys
 
 sys.path.append("../../")
@@ -118,13 +118,13 @@ delta_D = 1.02
 z = 0.01
 blob1 = Blob(r0, z, delta_D, Gamma, B0 * 10.0, norm, spectrum_dict, xi=xi)
 
-u_dens_synchr = blob1.u_dens_synchr  # energy density of synchr photons
+u_ph_synch = blob1.u_ph_synch  # energy density of synchr photons
 # u_dens * V_b is the total energy in the blob,
 # photons spend an average time of 0.75 * R_b/c in the blob
 # so the total energy flux is:
 # total energy in blob / (average time  * 4 pi dist^2)
 energy_flux_predicted = (
-    blob1.u_dens_synchr
+    blob.u_ph_synch
     * blob1.V_b
     / (0.75 * blob1.R_b / const.c.cgs)
     * np.power(blob1.d_L, -2)
@@ -143,7 +143,7 @@ print(
 ssc1 = SynchrotronSelfCompton(blob1, synch1)
 ssc1_sed = ssc1.sed_flux(nu)
 
-print("UB/Usynch = ", blob1.u_B / u_dens_synchr)
+print("UB/Usynch = ", blob1.U_B / u_ph_synch)
 print(
     "SED_synch/SED_SSC=",
     energy_flux_sim / np.trapz(ssc1_sed / (nu * const.h.cgs), nu * const.h.cgs),

--- a/tests/basic/test_gmax.py
+++ b/tests/basic/test_gmax.py
@@ -7,7 +7,7 @@ import astropy.constants as const
 from astropy.coordinates import Distance
 import matplotlib.pyplot as plt
 
-#plt.ion()
+# plt.ion()
 import sys
 
 sys.path.append("../../")


### PR DESCRIPTION
This small pull request adds functions to compute the peak flux and frequencies of the SEDs.

@jsitarek watchout I changed the names of two functions you introduced:
`u_B` -> `U_B` (in Finke and Dermer is always capitalised though other energy densities are not)
`u_dens_synchr` -> `u_ph_synch` (I have named the other functions computing the densities of photons as `u_ph`, also in the whole code we use _synch rather than _synchr).

Sorry for not asking to change that in the PR, I did not check carefully.
I modified test_gmax.py to work with the new functions, but as I said I'll make proper test scripts soon.