### PR TITLE
Include copy of license in the source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ The code is available in the [python package index](https://pypi.org/project/agn
 pip install agnpy
 ```
 
+The code can also be installed using `conda`
+
+```bash
+conda install -c conda-forge agnpy
+```
+
 ## tests
 A test suite is available in [`agnpy/tests`](https://github.com/cosimoNigro/agnpy/tree/master/agnpy/tests), to run it just type
 `pytest` in the main directory.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,7 @@ Notation and basic formulas are borrowed from [DermerMenon2009]_ which constitut
 
 Implementation
 ..............
-The numerical operations are delegated to `numpy arrays <https://numpy.org>`_, all the physical quantities computed are casted as `astropy Quantities <https://docs.astropy.org/en/stable/units/>`_. 
+The numerical operations are delegated to `numpy arrays <https://numpy.org>`_, all the physical quantities computed are casted as `astropy Quantities <https://docs.astropy.org/en/stable/units/>`_.
 
 License
 -------
@@ -22,11 +22,17 @@ The code is licensed under `GNU General Public License v3.0 <https://www.gnu.org
 
 Installation
 ------------
-The code is available in the `python package index <https://pypi.org/project/agnpy/>`_ and can be installed via `pip
+The code is available in the `python package index <https://pypi.org/project/agnpy/>`_ and can be installed via ``pip``
 
 .. code-block:: bash
 
     pip install agnpy
+
+The code can also be installed with ``conda``
+
+.. code-block:: bash
+
+    conda install -c conda-forge agnpy
 
 Dependencies
 ------------

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/cosimoNigro/agnpy",
     packages=setuptools.find_packages(),
+    include_package_data=True,
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",


### PR DESCRIPTION
This pull request adds the license file to the source distribution. Having it there makes it a bit easier to package agnpy for conda.