### PR TITLE
fixed wrong parameter extraction from the EC sherpa fit tutorial notebook

### DIFF
--- a/docs/tutorials/ec_dt_sherpa_fit.ipynb
+++ b/docs/tutorials/ec_dt_sherpa_fit.ipynb
@@ -175,7 +175,7 @@
     "    def calc(self, pars, x):\n",
     "        \"\"\"Evaluate the model\"\"\"\n",
     "        (log_k_e, p1, deltap1, log_gamma_b, log_gamma_min, log_gamma_max,z, d_L, \n",
-    "         delta_D, mu_s, log_B, log_R_b,log_r,log_L_disk, xi_dt, T_dt, R_dt) = pars\n",
+    "         delta_D, mu_s, log_B, alpha_jet, log_r,log_L_disk, xi_dt, T_dt, R_dt) = pars\n",
     "        # add units\n",
     "        k_e = 10**log_k_e*u.Unit(\"cm-3\")\n",
     "        gamma_b=10**log_gamma_b\n",
@@ -314,8 +314,8 @@
       "   bpwl_ec.log_gamma_max   4.62403      +/- 0           \n",
       "   bpwl_ec.log_B   -0.45354     +/- 0.0225065   \n",
       "   bpwl_ec.log_r   17.7439      +/- 0.0190161   \n",
-      "CPU times: user 1min 50s, sys: 8.95 s, total: 1min 59s\n",
-      "Wall time: 1min 59s\n"
+      "CPU times: user 2min 3s, sys: 9.47 s, total: 2min 13s\n",
+      "Wall time: 2min 13s\n"
      ]
     }
    ],
@@ -451,7 +451,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
variable has be extracted from the fit under wrong name in calc function of cell [5],

since it was also defined as global the bug (found by @pawel21) did not have effect on results