### PR TITLE
Absorption BLR for arbitrary  mu_s

### DIFF
--- a/agnpy/tests/test_geometry.py
+++ b/agnpy/tests/test_geometry.py
@@ -78,3 +78,43 @@ class TestUtilsGeometry:
         phi, mu = geom.phi_mu_re_ring(R_re, r, phi_re, uu, mu_s)
         cospsi = geom.cos_psi(mu_s, mu, phi)
         assert np.isclose(cospsi, 1, atol=0.01, rtol=0)
+
+    @pytest.mark.parametrize("R_re", [1e16 * u.cm, 1e17 * u.cm])
+    @pytest.mark.parametrize("r", [3.0e16 * u.cm, 2.0e17 * u.cm])
+    @pytest.mark.parametrize("uu", [5.0e16 * u.cm, 4.0e17 * u.cm])
+    @pytest.mark.parametrize("phi_re", np.linspace(0, 2 * np.pi, 5))
+    @pytest.mark.parametrize("mu_s", np.linspace(0, 1, 5))
+    def test_x_re_shell_mu_s_vs_ring(self, R_re, r, phi_re, uu, mu_s):
+        """Test that for mu_re=0. x_re_shell_mu_s gives the same results as 
+        x_re_ring_mu_s"""
+
+        x_ring = geom.x_re_ring_mu_s(R_re, r, phi_re, uu, mu_s)
+        mu_re = 0.01
+        x_shell = geom.x_re_shell_mu_s(R_re, r, phi_re, mu_re, uu, mu_s)
+        assert np.isclose(x_shell, x_ring, atol=0, rtol=0.01)
+
+    @pytest.mark.parametrize("R_re", [1e17 * u.cm])
+    @pytest.mark.parametrize("r", [3.0e16 * u.cm, 2.0e17 * u.cm])
+    @pytest.mark.parametrize("uu", [1.0e16 * u.cm, 4.0e17 * u.cm])
+    @pytest.mark.parametrize("phi_re", np.linspace(0, 2 * np.pi, 5))
+    @pytest.mark.parametrize("mu_re", np.linspace(-1, 1, 4))
+    def test_x_re_shell_mu_s_vs_on_axis(self, R_re, r, phi_re, mu_re, uu):
+        """Test that for mu_s=1. x_re_shell_mu_s gives the same results as 
+        x_re_shell"""
+        mu_s = 0.9999
+        x_on_axis = geom.x_re_shell(mu_re, R_re, r + uu)
+        x_shell = geom.x_re_shell_mu_s(R_re, r, phi_re, mu_re, uu, mu_s)
+        assert np.isclose(x_shell, x_on_axis, atol=0, rtol=0.01)
+
+    @pytest.mark.parametrize("phi_re", np.linspace(0, 2 * np.pi, 5))
+    def test_x_re_shell_mu_s(self, phi_re):
+        """Test that for a few simple cases x_re_shell_mu_s gives correct results"""
+
+        R_re = 1e17 * u.cm
+        r = 3e17 * u.cm
+        uu = 5e17 * u.cm
+        mu_re = 0.999
+        mu_s = 0.001
+        x_true = np.sqrt((r - R_re) ** 2 + uu ** 2)
+        x_shell = geom.x_re_shell_mu_s(R_re, r, phi_re, mu_re, uu, mu_s)
+        assert np.isclose(x_shell, x_true, atol=0, rtol=0.01)

--- a/agnpy/utils/geometry.py
+++ b/agnpy/utils/geometry.py
@@ -114,3 +114,38 @@ def phi_mu_re_ring(R_re, r, phi_re, u, mu_s):
     x = x_re_ring_mu_s(R_re, r, phi_re, u, mu_s)
     mu = dz / x
     return phi, mu
+
+
+def x_re_shell_mu_s(R_re, r, phi_re, mu_re, u, mu_s):
+    """distance between the blob and a spherical reprocessing material,
+    if the photon moved u along the mu_s direction starting from r position
+
+    Parameters
+    ----------
+    R_re : :class:`~astropy.units.Quantity`
+        distance from the BH to the reprocessing material
+    r : :class:`~astropy.units.Quantity`
+        distance (in cm) from the BH to the starting place of the photon
+    phi_re : :class:`~numpy.ndarray`
+        (array of) azimuth angle of the reprocessing material 
+    mu_re : :class:`~numpy.ndarray`
+        (array of) cos of zenith angle of the reprocessing material 
+    u : :class:`~numpy.ndarray`
+        (array of) distances (in cm) that the gamma ray has travelled 
+    mu_s : :class:`~astropy.units.Quantity`
+        direction of gamma ray  motion: cos angle to the jet axis. 
+        The gamma ray is moving in the direction of phi_re=0
+    """
+
+    sin_re = np.sqrt(1 - mu_re * mu_re)
+    sin_s = np.sqrt(1 - mu_s * mu_s)
+    x2 = (
+        R_re * R_re
+        + u * u
+        + r * r
+        - 2 * R_re * u * sin_re * np.cos(phi_re) * sin_s
+        - 2 * R_re * mu_re * (r + u * mu_s)
+        + 2 * r * u * mu_s
+    )
+
+    return np.sqrt(x2)

--- a/agnpy/utils/geometry.py
+++ b/agnpy/utils/geometry.py
@@ -149,3 +149,37 @@ def x_re_shell_mu_s(R_re, r, phi_re, mu_re, u, mu_s):
     )
 
     return np.sqrt(x2)
+
+
+def phi_mu_re_shell(R_re, r, phi_re, mu_re, u, mu_s):
+    """azimuth and  angle of the soft photon produced from  BLR shell
+    photon is produced at 
+    (R_re*sin(th_re)*cos(phi_re), R_re*sin(th_re)*sin(phi_re),R_re*cos(th_re))
+    and reached gamma ray at (u*sin(theta_s), 0, r+u*mu_s) distance between the blob and a ring of reprocessing material
+    if the photon moved u along the mu_s direction starting from r position
+
+    Parameters
+    ----------
+    R_re : :class:`~astropy.units.Quantity`
+        distance (in cm) from the BH to the reprocessing material
+    r : :class:`~astropy.units.Quantity`
+        distance (in cm) from the BH to the starting place of the photon
+    phi_re : :class:`~numpy.ndarray`
+        (array of) azimuth angle of the reprocessing material 
+    mu_re : :class:`~numpy.ndarray`
+        (array of) cos of zenith angle of the reprocessing material 
+    u : :class:`~numpy.ndarray`
+        (array of) distances (in cm) that the gamma ray has travelled 
+    mu_s : :class:`~astropy.units.Quantity`
+        direction of gamma ray  motion: cos angle to the jet axis. 
+        The gamma ray is moving in the direction of phi_re=0
+    """
+    sin_theta_s = np.sqrt(1 - mu_s * mu_s)
+    sin_re = np.sqrt(1 - mu_re * mu_re)
+    dx = u * sin_theta_s - R_re * sin_re * np.cos(phi_re)
+    dy = -R_re * sin_re * np.sin(phi_re)
+    dz = r + u * mu_s - R_re * mu_re
+    phi = np.arctan2(dy, dx)
+    x = x_re_shell_mu_s(R_re, r, phi_re, mu_re, u, mu_s)
+    mu = dz / x
+    return phi, mu


### PR DESCRIPTION
functions for computing BLR absorption for the case of an arbitrary mu_s
attached below is the comparison with the old code for the case of mu_s ~1
![tau_blr_on_axis_vs_general_r_10 _R_line_comparison](https://user-images.githubusercontent.com/33022433/110664199-7f59d200-81c7-11eb-8b6e-baf6300ba8d5.png)
![tau_blr_on_axis_vs_general_r_0 11_R_line_comparison](https://user-images.githubusercontent.com/33022433/110664205-7ff26880-81c7-11eb-85e5-cc4bc46b9e3b.png)
and updated notes with the formula also for BLR
[absorption_mu_s.pdf](https://github.com/cosimoNigro/agnpy/files/6117479/absorption_mu_s.pdf)
[absorption_mu_s.txt](https://github.com/cosimoNigro/agnpy/files/6117480/absorption_mu_s.txt)

the comparison with the point source behind the jet works fine and I reenabled it. While testing I saw some differences dependent on the binning used, but I will open a separate issue on this because I think this is a general problem. 