### PR TITLE
Linting and flaking

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,623 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-allow-list=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code. (This is an alternative name to extension-pkg-allow-list
+# for backward compatibility.)
+extension-pkg-whitelist=
+
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+fail-on=
+
+# Specify a score threshold to be exceeded before program exits with error.
+fail-under=10.0
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the ignore-list. The
+# regex matches against paths.
+ignore-paths=
+
+# Files or directories matching the regex patterns are skipped. The regex
+# matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        deprecated-operator-function,
+        deprecated-urllib-function,
+        xreadlines-attribute,
+        deprecated-sys-function,
+        exception-escape,
+        comprehension-escape
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'error', 'warning', 'refactor', and 'convention'
+# which contain the number of messages in each category, as well as 'statement'
+# which is the total number of statements analyzed. This score is used by the
+# global evaluation report (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit,argparse.parse_error
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it work,
+# install the 'python-enchant' package.
+spelling-dict=
+
+# List of comma separated words that should be considered directives if they
+# appear and the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+# Regular expression of note tags to take in consideration.
+#notes-rgx=
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis). It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=astropy.units,astropy.constants
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Ignore function signatures when computing similarities.
+ignore-signatures=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=any
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=any
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class constant names.
+class-const-naming-style=UPPER_CASE
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style.
+#class-const-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=any
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=any
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=
+
+# Output a graph (.gv or any supported image format) of external dependencies
+# to the given file (report RP0402 must not be disabled).
+ext-import-graph=
+
+# Output a graph (.gv or any supported image format) of all (i.e. internal and
+# external) dependencies to the given file (report RP0402 must not be
+# disabled).
+import-graph=
+
+# Output a graph (.gv or any supported image format) of internal dependencies
+# to the given file (report RP0402 must not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[CLASSES]
+
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "BaseException, Exception".
+overgeneral-exceptions=BaseException,
+                       Exception

--- a/agnpy/emission_regions/blob.py
+++ b/agnpy/emission_regions/blob.py
@@ -1,6 +1,9 @@
+"""This module describes the emission regions responsible for the
+acceleration of particles to relativistic energies. Beside physical quantities
+related to the emission itself it contains the electrons energy distributions"""
 import numpy as np
 import astropy.units as u
-from astropy.constants import e, c, m_e, sigma_T
+from astropy.constants import c, sigma_T
 from astropy.coordinates import Distance
 import matplotlib.pyplot as plt
 from .. import spectra
@@ -11,16 +14,16 @@ __all__ = ["Blob"]
 
 
 def init_spectrum_norm_dict(norm, spectrum_dict, norm_type="integral", V_b=None):
-    """initialize a spectrum from a normalisation and a spectrum dictionary of 
+    """initialize a spectrum from a normalisation and a spectrum dictionary of
     the following type
-    
+
     .. code-block:: python
 
         spectrum_dict = {
-            "type": "PowerLaw", 
+            "type": "PowerLaw",
             "parameters": {
-                "p": 2.8, 
-                "gamma_min": 1e2, 
+                "p": 2.8,
+                "gamma_min": 1e2,
                 "gamma_max": 1e7
             }
         }
@@ -42,7 +45,7 @@ def init_spectrum_norm_dict(norm, spectrum_dict, norm_type="integral", V_b=None)
 
     if norm.unit in (u.Unit("erg"), u.Unit("erg cm-3")) and norm_type != "integral":
         raise NameError(
-            "Normalisations different than 'integral' available only for 'spectrum_norm' in cm-3"
+            "Normalisation different than 'integral' available only for 'spectrum_norm' in cm-3"
         )
 
     # check the units of the normalisation
@@ -67,12 +70,9 @@ def init_spectrum_norm_dict(norm, spectrum_dict, norm_type="integral", V_b=None)
     elif norm.unit == u.Unit("erg"):
         if V_b is None:
             raise ValueError(
-                "if a normalisation in erg is provided, the volume V_b of the emission region msut be specified"
+                "if normalisation in erg provided, the volume V_b must be specified"
             )
-        else:
-            final_model = model.from_total_energy(
-                norm, V_b, **spectrum_dict["parameters"]
-            )
+        final_model = model.from_total_energy(norm, V_b, **spectrum_dict["parameters"])
 
     return final_model
 
@@ -102,13 +102,13 @@ class Blob:
         :math:`(\mathrm{d}E/\mathrm{d}t)_{\mathrm{acc}} = \xi c E / R_L`
 
     spectrum_norm : :class:`~astropy.units.Quantity`
-        normalisation of the electron spectra, by default can be, following 
+        normalisation of the electron spectra, by default can be, following
         the notation in [DermerMenon2009]_:
 
             - :math:`n_{e,\,tot}`: total electrons density, in :math:`\mathrm{cm}^{-3}`
             - :math:`u_e` : total electrons energy density, in :math:`\mathrm{erg}\,\mathrm{cm}^{-3}`
             - :math:`W_e` : total energy in electrons, in :math:`\mathrm{erg}`
-        
+
         see `spectrum_norm_type` for more details on the normalisation
 
     spectrum_dict : dictionary
@@ -117,23 +117,23 @@ class Blob:
         .. code-block:: python
 
             spectrum_dict = {
-                "type": "PowerLaw", 
+                "type": "PowerLaw",
                 "parameters": {
-                    "p": 2.8, 
-                    "gamma_min": 1e2, 
+                    "p": 2.8,
+                    "gamma_min": 1e2,
                     "gamma_max": 1e7
                 }
             }
 
     spectrum_norm_type : ["integral", "differential", "gamma=1"]
-        only with a normalisation in "cm-3" one can select among three types: 
+        only with a normalisation in "cm-3" one can select among three types:
 
-        * ``"integral"``: (default) the spectrum is set such that :math:`n_{e,\,tot}` equals the value provided by ``spectrum_norm``;  
-        
-        * ``"differential"``: the spectrum is set such that :math:`k_e` equals the value provided by ``spectrum_norm``;    
-        
+        * ``"integral"``: (default) the spectrum is set such that :math:`n_{e,\,tot}` equals the value provided by ``spectrum_norm``;
+
+        * ``"differential"``: the spectrum is set such that :math:`k_e` equals the value provided by ``spectrum_norm``;
+
         * ``"gamma=1"``: the spectrum is set such that :math:`n_e(\gamma=1)` equals the value provided by ``spectrum_norm``.
-        
+
     gamma_size : int
         size of the array of electrons Lorentz factors
     """
@@ -187,7 +187,7 @@ class Blob:
         self.gamma_to_integrate = np.logspace(1, 9, self.gamma_size)
 
     def set_gamma(self, gamma_min, gamma_max, gamma_size):
-        """set the array of Lorentz factors to be used for integration in the 
+        """set the array of Lorentz factors to be used for integration in the
         frame comoving with the blob"""
         self.gamma_min = gamma_min
         self.gamma_max = gamma_max
@@ -200,7 +200,7 @@ class Blob:
     def set_spectrum(
         self, spectrum_norm, spectrum_dict, spectrum_norm_type, gamma_size=200
     ):
-        r"""set the spectrum :math:`n_e` for the electrons accelerated in the 
+        r"""set the spectrum :math:`n_e` for the electrons accelerated in the
         blob, reset also the array of Lorentz factor given the `gamma_min` and
         `gamma_max` in the parameters dictionary"""
         self.set_gamma(
@@ -251,7 +251,7 @@ class Blob:
         self.delta_D = delta_D
 
     def N_e(self, gamma):
-        r"""number of electrons as a function of the Lorentz factor, 
+        r"""number of electrons as a function of the Lorentz factor,
         :math:`N_e(\gamma') = V_b\,n_e(\gamma')`"""
         return self.V_b * self.n_e(gamma)
 
@@ -303,7 +303,7 @@ class Blob:
 
     @property
     def k_eq(self):
-        """equipartition parameter: ratio between totoal electron energy density  
+        """equipartition parameter: ratio between totoal electron energy density
         magnetic field energy density, Eq. 7.75 of [DermerMenon2009]_"""
         return (self.u_e / self.U_B).to_value("")
 
@@ -312,7 +312,7 @@ class Blob:
         r"""jet power in electrons
 
         .. math::
-            P_{jet,\,e} = 2 \pi R_b^2 \beta \Gamma^2 c u_e
+            P_{\mathrm{jet},\,e} = 2 \pi R_b^2 \beta \Gamma^2 c u_e
         """
         prefactor = (
             2 * np.pi * np.power(self.R_b, 2) * self.Beta * np.power(self.Gamma, 2) * c
@@ -324,7 +324,7 @@ class Blob:
         r"""jet power in magnetic field
 
         .. math::
-            P_{jet,\,B} = 2 \pi R_b^2 beta \Gamma^2 c \frac{B^2}{8\pi}
+            P_{\mathrm{jet},\,B} = 2 \pi R_b^2 \beta \Gamma^2 c \frac{B^2}{8\pi}
         """
         prefactor = (
             2 * np.pi * np.power(self.R_b, 2) * self.Beta * np.power(self.Gamma, 2) * c
@@ -335,23 +335,24 @@ class Blob:
     def u_ph_synch(self):
         r"""energy density of the synchrotron photons energy losses are:
 
-        .. math::        
-            (\mathrm{d}E/\mathrm{d}t)_{\mathrm{synch}} = 4 / 3 \sigma_T c U_B \gamma^2 
+        .. math::
+            (\mathrm{d}E/\mathrm{d}t)_{\mathrm{synch}} = 4 / 3 \sigma_T c U_B \gamma^2
 
-        the radiation stays an average time of :math:`(3/4) (R_b/c)` (the factor of 3/4 cames from averaging over a sphere), 
+        the radiation stays an average time of :math:`(3/4) (R_b/c)`
+        (the factor of 3/4 cames from averaging over a sphere),
         so an e- with Lorentz factor :math:`\gamma` produces:
 
-        .. math::        
-            0.75\,(\mathrm{d}E/\mathrm{d}t)_{\mathrm{synch}}\,(R_b/c)\,/\,V_b 
+        .. math::
+            0.75\,(\mathrm{d}E/\mathrm{d}t)_{\mathrm{synch}}\,(R_b/c)\,/\,V_b
 
         of radiation. We need to integrate over the electron spectrum  (and multiply back by V_b)
 
-        .. math::        
-            0.75\,\int n_e(\gamma) (\mathrm{d}E/\mathrm{d}t)_{\mathrm{synch}}  R_b  \mathrm{d}\gamma
-        
+        .. math::
+            0.75\,\int n_e(\gamma) (\mathrm{d}E/\mathrm{d}t)_{\mathrm{synch}} R_b \mathrm{d}\gamma
+
         so
 
-        .. math::        
+        .. math::
             u_{\mathrm{synch}} = \sigma_T  U_B  R_b  \int n_e(\gamma) \, \gamma^2 \mathrm{d}\gamma
 
         WARNING: this does not take into account SSA!
@@ -366,8 +367,8 @@ class Blob:
 
     def plot_n_e(self, ax=None, gamma_power=0):
         """plot the  electron distribution
-        
-        Parameters 
+
+        Parameters
         ----------
         ax : :class:`~matplotlib.axes.Axes`, optional
             Axis


### PR DESCRIPTION
Dear @pawel21,

thanks for helping me with linting and flaking our code.
From a bit of reading it seems that there is some overlap between the checks that `pylint` and `flake8` perform.

From a superficial reading, it seems to me that `pylint` is the more complete, so I would suggest use it as reference.

As you rightly pointed out though, there are a lot of error and warning messages printed, but you can avoid some of them by specifying some settings. For example, by default, variable, attributes and method should all follow the `snake_case` notation, so there should be no upper case letters. In our case this is a bit difficult as we try to "mimic" the math notation (e.g. the magnetic field is always upper case) or, for example, there is a clear difference between a lower and upper case Lorentz factor gamma.
I disabled some of this warning through a `.pylintrc` file that you can find in this PR. `pylint` will automatically detect and use it. After that, most of the warnings left were due to trailing whitespaces in the comments - I suggest you use some feature of your text editor to spot and remove them.

To start the global linting I used `pylint` on the `emission_regions/blob.py` module. After some corrections this is the output of `pylint` that I get by running
```shell
~/work/agnpy pylint_and_flake8 ❯ pylint agnpy/emission_regions/blob.py                                                                                           Py base 12:33:17
************* Module agnpy.emission_regions.blob
agnpy/emission_regions/blob.py:109:0: C0301: Line too long (101/100) (line-too-long)
agnpy/emission_regions/blob.py:131:0: C0301: Line too long (133/100) (line-too-long)
agnpy/emission_regions/blob.py:133:0: C0301: Line too long (119/100) (line-too-long)
agnpy/emission_regions/blob.py:135:0: C0301: Line too long (124/100) (line-too-long)
agnpy/emission_regions/blob.py:281:0: C0301: Line too long (109/100) (line-too-long)
agnpy/emission_regions/blob.py:290:0: C0301: Line too long (109/100) (line-too-long)
agnpy/emission_regions/blob.py:80:0: R0902: Too many instance attributes (21/7) (too-many-instance-attributes)
agnpy/emission_regions/blob.py:141:4: W0102: Dangerous default value {} as argument (dangerous-default-value)
agnpy/emission_regions/blob.py:141:4: R0913: Too many arguments (11/5) (too-many-arguments)
agnpy/emission_regions/blob.py:183:8: W0201: Attribute 'gamma_size' defined outside __init__ (attribute-defined-outside-init)
agnpy/emission_regions/blob.py:194:8: W0201: Attribute 'gamma_size' defined outside __init__ (attribute-defined-outside-init)
agnpy/emission_regions/blob.py:184:8: W0201: Attribute 'gamma' defined outside __init__ (attribute-defined-outside-init)
agnpy/emission_regions/blob.py:196:8: W0201: Attribute 'gamma' defined outside __init__ (attribute-defined-outside-init)
agnpy/emission_regions/blob.py:192:8: W0201: Attribute 'gamma_min' defined outside __init__ (attribute-defined-outside-init)
agnpy/emission_regions/blob.py:193:8: W0201: Attribute 'gamma_max' defined outside __init__ (attribute-defined-outside-init)

------------------------------------------------------------------
Your code has been rated at 8.53/10 (previous run: 8.53/10, +0.00)
```
much more reduced with respect to initial list of warnings we were getting.
I think it's a good score, the warning left are due to too long comment lines (that cannot be split because they contain math expressions or will break the itemising in sphinx. Then there are some warnings on the number of arguments and attributes of a class and where they should be initialised, but I think the last word on these should be on the developers. So I will not disable these warnings.

As a bonus we get also a decent score with `flake8`. Only warning about the length of the comments are left
```shell
~/work/agnpy pylint_and_flake8 ❯ flake8 agnpy/emission_regions/blob.py                                                                                        6s Py base 12:45:15
agnpy/emission_regions/blob.py:3:80: E501 line too long (80 > 79 characters)
agnpy/emission_regions/blob.py:16:80: E501 line too long (81 > 79 characters)
agnpy/emission_regions/blob.py:46:80: E501 line too long (84 > 79 characters)
agnpy/emission_regions/blob.py:48:80: E501 line too long (96 > 79 characters)
agnpy/emission_regions/blob.py:73:80: E501 line too long (84 > 79 characters)
agnpy/emission_regions/blob.py:75:80: E501 line too long (87 > 79 characters)
agnpy/emission_regions/blob.py:83:80: E501 line too long (89 > 79 characters)
agnpy/emission_regions/blob.py:108:80: E501 line too long (87 > 79 characters)
agnpy/emission_regions/blob.py:109:80: E501 line too long (101 > 79 characters)
agnpy/emission_regions/blob.py:131:80: E501 line too long (133 > 79 characters)
agnpy/emission_regions/blob.py:133:80: E501 line too long (119 > 79 characters)
agnpy/emission_regions/blob.py:135:80: E501 line too long (124 > 79 characters)
agnpy/emission_regions/blob.py:178:80: E501 line too long (87 > 79 characters)
agnpy/emission_regions/blob.py:228:80: E501 line too long (87 > 79 characters)
agnpy/emission_regions/blob.py:263:80: E501 line too long (98 > 79 characters)
agnpy/emission_regions/blob.py:272:80: E501 line too long (98 > 79 characters)
agnpy/emission_regions/blob.py:281:80: E501 line too long (109 > 79 characters)
agnpy/emission_regions/blob.py:290:80: E501 line too long (109 > 79 characters)
agnpy/emission_regions/blob.py:318:80: E501 line too long (87 > 79 characters)
agnpy/emission_regions/blob.py:327:80: E501 line too long (80 > 79 characters)
agnpy/emission_regions/blob.py:330:80: E501 line too long (87 > 79 characters)
agnpy/emission_regions/blob.py:339:80: E501 line too long (86 > 79 characters)
agnpy/emission_regions/blob.py:348:80: E501 line too long (97 > 79 characters)
agnpy/emission_regions/blob.py:351:80: E501 line too long (98 > 79 characters)
agnpy/emission_regions/blob.py:356:80: E501 line too long (98 > 79 characters)
agnpy/emission_regions/blob.py:364:80: E501 line too long (82 > 79 characters)
agnpy/emission_regions/blob.py:381:80: E501 line too long (87 > 79 characters)
```

@pawel can you continue on this branch with linting the rest of the code?
I think a score around 8 is acceptable.


 