### PR TITLE
Do not automatically compute the luminosity distance from the redshift

### DIFF
--- a/agnpy/absorption/absorption.py
+++ b/agnpy/absorption/absorption.py
@@ -4,7 +4,7 @@ import numpy as np
 import astropy.units as u
 from astropy.io import fits
 from astropy.constants import c, G, m_e, sigma_T
-from scipy.interpolate import interp2d
+from scipy.interpolate import RegularGridInterpolator
 from ..utils.math import (
     axes_reshaper,
     log,
@@ -122,7 +122,7 @@ class Absorption:
         epsilon_1 = nu_to_epsilon_prime(nu, z)
         s = epsilon_0 * epsilon_1 * (1 - mu_s) / 2
         integral = (1 - mu_s) * sigma(s) / r
-        prefactor = L_0 / (4 * np.pi * epsilon_0 * m_e * c ** 3)
+        prefactor = L_0 / (4 * np.pi * epsilon_0 * m_e * c**3)
         return (prefactor * integral).to_value("")
 
     def tau_ps_behind_blob(self, nu):
@@ -174,10 +174,10 @@ class Absorption:
         _cos_psi = cos_psi(mu_s, _mu, phi)
         s = _epsilon_1 * epsilon_0 * (1 - _cos_psi) / 2
 
-        integrand = (1 - _cos_psi) / x ** 2 * sigma(s)
+        integrand = (1 - _cos_psi) / x**2 * sigma(s)
         # integrate
         integral = np.trapz(integrand, uu, axis=0)
-        prefactor = L_0 / (4 * np.pi * epsilon_0 * m_e * c ** 3)
+        prefactor = L_0 / (4 * np.pi * epsilon_0 * m_e * c**3)
         return (prefactor * integral).to_value("")
 
     def tau_ps_behind_blob_mu_s(self, nu):
@@ -239,7 +239,7 @@ class Absorption:
             array of the tau values corresponding to each frequency
         """
         # conversions
-        R_g = (G * M_BH / c ** 2).to("cm")
+        R_g = (G * M_BH / c**2).to("cm")
         r_tilde = to_R_g_units(r, M_BH)
         R_in_tilde = to_R_g_units(R_in, M_BH)
         R_out_tilde = to_R_g_units(R_out, M_BH)
@@ -252,14 +252,14 @@ class Absorption:
         )
         _epsilon = SSDisk.evaluate_epsilon(L_disk, M_BH, eta, _R_tilde)
         _phi_disk = 1 - (R_in_tilde / _R_tilde) ** (1 / 2)
-        _mu = (1 + (_R_tilde ** 2 / _l_tilde ** 2)) ** (-1 / 2)
+        _mu = (1 + (_R_tilde**2 / _l_tilde**2)) ** (-1 / 2)
         _cos_psi = cos_psi(mu_s, _mu, _phi)
         s = _epsilon * _epsilon_1 * (1 - _cos_psi) / 2
         integrand = (
             1
-            / _l_tilde ** 2
-            / _R_tilde ** 2
-            / (1 + (_R_tilde ** 2 / _l_tilde ** 2)) ** (3 / 2)
+            / _l_tilde**2
+            / _R_tilde**2
+            / (1 + (_R_tilde**2 / _l_tilde**2)) ** (3 / 2)
             * _phi_disk
             / _epsilon
             * sigma(s)
@@ -268,7 +268,7 @@ class Absorption:
         integral_R_tilde = np.trapz(integrand, R_tilde, axis=0)
         integral_phi = np.trapz(integral_R_tilde, phi, axis=0)
         integral = np.trapz(integral_phi, l_tilde, axis=0)
-        prefactor = 3 * L_disk / ((4 * np.pi) ** 2 * eta * m_e * c ** 3 * R_g)
+        prefactor = 3 * L_disk / ((4 * np.pi) ** 2 * eta * m_e * c**3 * R_g)
         return (prefactor * integral).to_value("")
 
     def tau_ss_disk(self, nu):
@@ -350,13 +350,13 @@ class Absorption:
         _mu_star = mu_star_shell(_mu, R_line, _l)
         _cos_psi = cos_psi(mu_s, _mu_star, _phi)
         s = _epsilon_1 * epsilon_line * (1 - _cos_psi) / 2
-        integrand = (1 - _cos_psi) / x ** 2 * sigma(s)
+        integrand = (1 - _cos_psi) / x**2 * sigma(s)
         # integrate
         integral_mu = np.trapz(integrand, mu, axis=0)
         integral_phi = np.trapz(integral_mu, phi, axis=0)
         integral = np.trapz(integral_phi, l, axis=0)
         prefactor = (L_disk * xi_line) / (
-            (4 * np.pi) ** 2 * epsilon_line * m_e * c ** 3
+            (4 * np.pi) ** 2 * epsilon_line * m_e * c**3
         )
         return (prefactor * integral).to_value("")
 
@@ -413,7 +413,7 @@ class Absorption:
         uu = np.logspace(-5, 5, u_size) * r
 
         # check if for any uu value the position of the photon is too close to the BLR
-        x_cross = np.sqrt(r ** 2 + uu ** 2 + 2 * uu * r * mu_s)
+        x_cross = np.sqrt(r**2 + uu**2 + 2 * uu * r * mu_s)
         idx = np.isclose(x_cross, R_line, rtol=min_rel_distance)
         if idx.any():
             uu[idx] += min_rel_distance * R_line
@@ -433,13 +433,13 @@ class Absorption:
         # angle between the soft photon and gamma ray
         _cos_psi = cos_psi(mu_s, _mu_star, _phi)
         s = _epsilon_1 * epsilon_line * (1 - _cos_psi) / 2
-        integrand = (1 - _cos_psi) / x ** 2 * sigma(s)
+        integrand = (1 - _cos_psi) / x**2 * sigma(s)
         # integrate
         integral_mu = np.trapz(integrand, mu, axis=0)
         integral_phi = np.trapz(integral_mu, phi, axis=0)
         integral = np.trapz(integral_phi, uu, axis=0)
         prefactor = (L_disk * xi_line) / (
-            (4 * np.pi) ** 2 * epsilon_line * m_e * c ** 3
+            (4 * np.pi) ** 2 * epsilon_line * m_e * c**3
         )
         return (prefactor * integral).to_value("")
 
@@ -532,11 +532,11 @@ class Absorption:
         _mu = _l / x
         _cos_psi = cos_psi(mu_s, _mu, _phi)
         s = _epsilon_1 * epsilon_dt * (1 - _cos_psi) / 2
-        integrand = (1 - _cos_psi) / x ** 2 * sigma(s)
+        integrand = (1 - _cos_psi) / x**2 * sigma(s)
         # integrate
         integral_phi = np.trapz(integrand, phi, axis=0)
         integral = np.trapz(integral_phi, l, axis=0)
-        prefactor = (L_disk * xi_dt) / (8 * np.pi ** 2 * epsilon_dt * m_e * c ** 3)
+        prefactor = (L_disk * xi_dt) / (8 * np.pi**2 * epsilon_dt * m_e * c**3)
         return (prefactor * integral).to_value("")
 
     @staticmethod
@@ -597,11 +597,11 @@ class Absorption:
         _phi, _mu = phi_mu_re_ring(R_dt, r, _phi_re, _u, mu_s)
         _cos_psi = cos_psi(mu_s, _mu, _phi)
         s = _epsilon_1 * epsilon_dt * (1 - _cos_psi) / 2
-        integrand = (1 - _cos_psi) / x ** 2 * sigma(s)
+        integrand = (1 - _cos_psi) / x**2 * sigma(s)
         # integrate
         integral_phi = np.trapz(integrand, phi_re, axis=0)
         integral = np.trapz(integral_phi, uu, axis=0)
-        prefactor = (L_disk * xi_dt) / (8 * np.pi ** 2 * epsilon_dt * m_e * c ** 3)
+        prefactor = (L_disk * xi_dt) / (8 * np.pi**2 * epsilon_dt * m_e * c**3)
         return (prefactor * integral).to_value("")
 
     def tau_dt(self, nu):
@@ -685,9 +685,9 @@ class Absorption:
                 c
                 * np.power(blob.R_b, 2)
                 * np.power(blob.delta_D, 4)
-                * epsilon ** 2
+                * epsilon**2
                 * m_e
-                * c ** 2
+                * c**2
             )
         ).to("cm-3")
 
@@ -788,15 +788,21 @@ class EBL:
         self.z_ref = np.unique(f["SPECTRA"].data["PARAMVAL"])
         self.values_ref = np.unique(f["SPECTRA"].data["INTPSPEC"], axis=0)
 
-    def interpolate_absorption_table(self, kind="linear"):
+    def interpolate_absorption_table(self, method="linear"):
         """interpolate the reference values, choose the kind of interpolation"""
-        log10_energy_ref = np.log10(self.energy_ref.to_value("eV"))
-        self.interpolated_model = interp2d(
-            log10_energy_ref, self.z_ref, self.values_ref, kind=kind
+        log10_energy_ref = np.log10(self.energy_ref.to_value("keV"))
+        self.interpolated_model = RegularGridInterpolator(
+            (log10_energy_ref, self.z_ref),
+            self.values_ref.T,
+            method=method,
+            bounds_error=False,
+            fill_value=1,
         )
 
-    def absorption(self, z, nu):
+    def absorption(self, nu, z):
         "This function returns the attenuation of the emission by EBL"
-        energy = nu.to_value("eV", equivalencies=u.spectral())
+        energy = nu.to_value("keV", equivalencies=u.spectral())
         log10_energy = np.log10(energy)
-        return self.interpolated_model(log10_energy, z)
+        z = z * np.ones_like(log10_energy)
+        xx = np.column_stack((log10_energy, z))
+        return self.interpolated_model(xx)

--- a/agnpy/emission_regions/blob.py
+++ b/agnpy/emission_regions/blob.py
@@ -54,6 +54,7 @@ class Blob:
         self,
         R_b=1e16 * u.cm,
         z=0.069,
+        d_L=None,
         delta_D=10,
         Gamma=10,
         B=1 * u.G,
@@ -65,6 +66,8 @@ class Blob:
     ):
         self.R_b = R_b.to("cm")
         self.z = z
+        # if the luminosity distance is not specified, it will be computed from z
+        self.d_L = Distance(z=self.z).cgs if d_L is None else d_L
         self.delta_D = delta_D
         self.Gamma = Gamma
         self.B = B
@@ -88,11 +91,6 @@ class Blob:
         :math:`t_{\rm var} = \frac{(1 + z) R_{\rm b}}{c \delta_{\rm D}}`.
         """
         return (((1 + self.z) * self.R_b) / (c * self.delta_D)).to("d")
-
-    @property
-    def d_L(self):
-        """Luminosity distance."""
-        return Distance(z=self.z).cgs
 
     @property
     def Beta(self):

--- a/agnpy/emission_regions/blob.py
+++ b/agnpy/emission_regions/blob.py
@@ -189,7 +189,7 @@ class Blob:
         """Setter of the proton distribution."""
         self._n_p = spectrum
         # set also the array of Lorentz factor of the protons
-        self.set_gamma_p(200, self._n_p.gamma_min,  self._n_p.gamma_max)
+        self.set_gamma_p(200, self._n_p.gamma_min, self._n_p.gamma_max)
 
     def __str__(self):
         """Printable summary of the blob."""

--- a/agnpy/synchrotron/synchrotron.py
+++ b/agnpy/synchrotron/synchrotron.py
@@ -178,7 +178,7 @@ class Synchrotron:
         V_b = 4 / 3 * np.pi * np.power(R_b, 3)
         N_e = V_b * n_e.evaluate(_gamma, *args)
         # fold the electron distribution with the synchrotron power
-        integrand = N_e * single_electron_synch_power(B_cgs, _epsilon, _gamma)
+        integrand = N_e * single_particle_synch_power(B_cgs, _epsilon, _gamma)
         emissivity = integrator(integrand, gamma, axis=0).reshape(epsilon.shape)
         prefactor = np.power(delta_D, 4) / (4 * np.pi * np.power(d_L, 2))
         sed = (prefactor * epsilon * emissivity).to("erg cm-2 s-1")

--- a/agnpy/tests/test_absorption.py
+++ b/agnpy/tests/test_absorption.py
@@ -235,8 +235,8 @@ def sigma_pp(b):
         sigma_T
         * 3.0
         / 16.0
-        * (1 - b ** 2)
-        * (2 * b * (b ** 2 - 2) + (3 - b ** 4) * np.log((1 + b) / (1 - b)))
+        * (1 - b**2)
+        * (2 * b * (b**2 - 2) + (3 - b**4) * np.log((1 + b) / (1 - b)))
     )
 
 
@@ -265,11 +265,11 @@ class TestAbsorptionMuS:
 
         eps = (2.7 * temp * k_B).to("eV")  # energy of soft photons
         # soft photon density
-        nph = (L_disk * xi_DT / (4 * np.pi * (r ** 2 + R_DT ** 2)) / c / eps).to("cm-3")
+        nph = (L_disk * xi_DT / (4 * np.pi * (r**2 + R_DT**2)) / c / eps).to("cm-3")
 
         E = nu_ref.to("eV", equivalencies=u.spectral())
         cospsi = 0  # assume perpendicular scattering
-        beta2 = 1 - 2 * mec2 ** 2 / (E * eps * (1 - cospsi))
+        beta2 = 1 - 2 * mec2**2 / (E * eps * (1 - cospsi))
         beta2[beta2 < 0] = 0  # below the threshold
         # for tau calculations we assume that gamma ray moves
         # roughtly the characteristic distance of ~R_DT
@@ -311,12 +311,12 @@ class TestAbsorptionMuS:
         _x = np.sqrt(r * r + _u * _u + 2 * mu_s * _u * r)
 
         # soft photon density
-        _nph = (L_disk * xi_DT / (4 * np.pi * _x ** 2) / c / eps).to("cm-3")
+        _nph = (L_disk * xi_DT / (4 * np.pi * _x**2) / c / eps).to("cm-3")
 
         _E = _nu_ref.to("eV", equivalencies=u.spectral())
-        _cospsi = (_u ** 2 + _x ** 2 - r ** 2) / (2 * _u * _x)
+        _cospsi = (_u**2 + _x**2 - r**2) / (2 * _u * _x)
 
-        _beta2 = 1 - 2 * mec2 ** 2 / (_E * eps * (1 - _cospsi))
+        _beta2 = 1 - 2 * mec2**2 / (_E * eps * (1 - _cospsi))
         _beta2[_beta2 < 0] = 0
 
         integrand = sigma_pp(np.sqrt(_beta2)) * _nph * (1 - _cospsi)
@@ -335,7 +335,7 @@ class TestAbsorptionMuS:
 
     @pytest.mark.parametrize("r_to_R", ["0.11", "10."])
     def test_abs_blr_mu_s_vs_on_axis(self, r_to_R):
-        """check if the codes computing absorption on BLR for mu_s = 1 and !=1 cases are consistent """
+        """check if the codes computing absorption on BLR for mu_s = 1 and !=1 cases are consistent"""
         # broad line region
         L_disk = 2e46 * u.Unit("erg s-1")
         xi_line = 0.024
@@ -406,7 +406,7 @@ class TestAbsorptionMuS:
         """
         # u = alpha * r
         alpha = 1.0e-5 * 1.0e10 ** (ipoint / (npoints - 1.0))
-        return 1 / np.sqrt(alpha ** 2 + 2 * alpha * mu_s + 1)
+        return 1 / np.sqrt(alpha**2 + 2 * alpha * mu_s + 1)
 
     @pytest.mark.parametrize("r_R_line", [1, find_r_for_x_cross(0.99, 60, 100)])
     def test_tau_blr_mus_Rline(self, r_R_line):
@@ -475,10 +475,10 @@ class TestAbsorptionMuS:
         tau = absorb.tau(nu_tau)
 
         # now simplified calculations using Eq. 37 of Finke 2008
-        mec2 = (m_e * c ** 2).to("eV")
+        mec2 = (m_e * c**2).to("eV")
         eps1 = e_tau / mec2
         eps1p = eps1 * (1 + z) / blob.delta_D
-        eps_bar = 2 * blob.delta_D ** 2 / (1 + z) ** 2 / eps1
+        eps_bar = 2 * blob.delta_D**2 / (1 + z) ** 2 / eps1
         nu_bar = (eps_bar * mec2).to("Hz", equivalencies=u.spectral())
         synch = Synchrotron(blob, ssa=True)
         synch_sed_ebar = synch.sed_flux(nu_bar)
@@ -488,7 +488,7 @@ class TestAbsorptionMuS:
             * sigma_T
             * Distance(z=z) ** 2
             * eps1p
-            / (2 * m_e * c ** 3 * blob.R_b * blob.delta_D ** 4)
+            / (2 * m_e * c**3 * blob.R_b * blob.delta_D**4)
         )
         tau_delta = tau_delta.to("")
 
@@ -544,7 +544,7 @@ class TestEBL:
         # define the ebl model, evaluate it at the reference energies
         ebl = EBL(model)
         nu_ref = ebl.energy_ref.to("Hz", equivalencies=u.spectral())
-        absorption = ebl.absorption(z, nu_ref)
+        absorption = ebl.absorption(nu_ref, z)
         # find in the reference values the spectra for this redshift
         z_idx = np.abs(z - ebl.z_ref).argmin()
         absorption_ref = ebl.values_ref[z_idx]

--- a/agnpy/tests/test_emission_regions.py
+++ b/agnpy/tests/test_emission_regions.py
@@ -16,14 +16,12 @@ class TestBlob:
         attributes are modified."""
         blob = Blob()
         blob.R_b = 1e17 * u.cm
-        blob.z = 2.1
         blob.delta_D = 8
         blob.Gamma = 5
         blob.B = 2 * u.G
         assert u.isclose(
             blob.V_b, 4.1887902e51 * u.Unit("cm3"), atol=0 * u.Unit("cm3"), rtol=1e-3
         )
-        assert u.isclose(blob.d_L, 5.21497473e28 * u.cm, atol=0 * u.cm, rtol=1e-3)
         assert np.isclose(blob.Beta, 0.9798, atol=0, rtol=1e-3)
         assert u.isclose(blob.theta_s, 5.67129265 * u.deg, atol=0 * u.deg, rtol=1e-3)
         assert u.isclose(
@@ -32,9 +30,19 @@ class TestBlob:
             atol=0 * u.Unit(Gauss_cgs_unit),
             rtol=1e-3,
         )
+
         # test the manual setting of delta_D
         blob.set_delta_D(Gamma=10, theta_s=20 * u.deg)
         assert np.allclose(blob.delta_D, 1.53804, atol=0, rtol=1e-3)
+
+        # test on z and d_L
+        # - automatically set d_L
+        blob = Blob(z=2.1)
+        assert u.isclose(blob.d_L, 5.21497473e28 * u.cm, atol=0 * u.cm, rtol=1e-3)
+        # - set a different d_L, not computed from z
+        d_L = 1.5e27 * u.cm
+        blob = Blob(z=0.1, d_L=d_L)
+        assert u.isclose(blob.d_L, d_L, atol=0 * u.cm, rtol=1e-5)
 
     def test_particles_spectra(self):
         """Test for the blob properties related to the particle spectra."""

--- a/docs/snippets/ebl_models.py
+++ b/docs/snippets/ebl_models.py
@@ -5,22 +5,21 @@ from agnpy.absorption import EBL
 import matplotlib.pyplot as plt
 from agnpy.utils.plot import load_mpl_rc
 
+load_mpl_rc()
 
 # redshift and array of frequencies over which to evaluate the absorption
-z = 0.5
-nu = np.logspace(15, 28, 200) * u.Hz
-E = nu.to("eV", equivalencies=u.spectral())
-
-load_mpl_rc()
+z = 1.0
+nu = np.logspace(22, 28, 200) * u.Hz
+E = nu.to("TeV", equivalencies=u.spectral())
 
 for model in ["franceschini", "dominguez", "finke", "saldana-lopez"]:
     ebl = EBL(model)
-    absorption = ebl.absorption(z, nu)
+    absorption = ebl.absorption(nu, z)
     plt.loglog(E, absorption, label=model)
 
-plt.xlabel(r"$E\,/\,{\rm eV}$")
+plt.xlabel(r"$E\,/\,{\rm TeV}$")
 plt.title("EBL absorption at z=1")
 plt.ylabel("absorption")
-plt.ylim([1e-4, 2])
+plt.ylim([1e-2, 2])
 plt.legend()
 plt.show()


### PR DESCRIPTION
On request of @IlariaViale, this PR allows to manually specify the luminosity distance when initialising the blob.
If not specified, the `d_L` will be computed from z as before.

```python
In [1]: from agnpy.emission_regions import Blob

In [2]: blob = Blob(z=0.1)

In [3]: blob.d_L
Out[3]: <Distance 1.4682341e+27 cm>

In [4]: import astropy.units as u

In [5]: d_L = 1.5e27 * u.cm

In [7]: blob = Blob(z=0.1, d_L=d_L)

In [6]: blob.d_L
Out[6]: <Quantity 1.5e+27 cm>
```
@IlariaViale can you take a look?