### PR TITLE
added cosmology as an optional argument instead of d_L

### DIFF
--- a/agnpy/emission_regions/blob.py
+++ b/agnpy/emission_regions/blob.py
@@ -48,7 +48,7 @@ class Blob:
         size of the array of electrons Lorentz factors
     gamma_p_size : int
         size of the array of protons Lorentz factors
-    cosmology : :class:`~astropy.units.Quantity`
+    cosmology : :class:`~astropy.cosmology.Cosmology`
         (optional) cosmology used to convert the redshift in a distance,
         see https://docs.astropy.org/en/stable/api/astropy.cosmology.Cosmology.html
     """

--- a/agnpy/emission_regions/blob.py
+++ b/agnpy/emission_regions/blob.py
@@ -48,13 +48,15 @@ class Blob:
         size of the array of electrons Lorentz factors
     gamma_p_size : int
         size of the array of protons Lorentz factors
+    cosmology : :class:`~astropy.units.Quantity`
+        (optional) cosmology used to convert the redshift in a distance,
+        see https://docs.astropy.org/en/stable/api/astropy.cosmology.Cosmology.html
     """
 
     def __init__(
         self,
         R_b=1e16 * u.cm,
         z=0.069,
-        d_L=None,
         delta_D=10,
         Gamma=10,
         B=1 * u.G,
@@ -63,11 +65,12 @@ class Blob:
         xi=1.0,
         gamma_e_size=200,
         gamma_p_size=200,
+        cosmology=None
     ):
         self.R_b = R_b.to("cm")
         self.z = z
         # if the luminosity distance is not specified, it will be computed from z
-        self.d_L = Distance(z=self.z).cgs if d_L is None else d_L
+        self.d_L = Distance(z=self.z, cosmology=cosmology).cgs
         self.delta_D = delta_D
         self.Gamma = Gamma
         self.B = B

--- a/agnpy/emission_regions/blob.py
+++ b/agnpy/emission_regions/blob.py
@@ -50,7 +50,7 @@ class Blob:
         size of the array of protons Lorentz factors
     cosmology : :class:`~astropy.cosmology.Cosmology`
         (optional) cosmology used to convert the redshift in a distance,
-        see https://docs.astropy.org/en/stable/api/astropy.cosmology.Cosmology.html
+        see https://docs.astropy.org/en/stable/cosmology/index.html
     """
 
     def __init__(

--- a/agnpy/tests/test_emission_regions.py
+++ b/agnpy/tests/test_emission_regions.py
@@ -2,6 +2,7 @@
 import numpy as np
 import astropy.units as u
 from astropy.constants import m_e, m_p
+from astropy.cosmology import Planck18
 import pytest
 from agnpy.spectra import PowerLaw, BrokenPowerLaw
 from agnpy.emission_regions import Blob
@@ -39,9 +40,9 @@ class TestBlob:
         # - automatically set d_L
         blob = Blob(z=2.1)
         assert u.isclose(blob.d_L, 5.21497473e28 * u.cm, atol=0 * u.cm, rtol=1e-3)
-        # - set a different d_L, not computed from z
-        d_L = 1.5e27 * u.cm
-        blob = Blob(z=0.1, d_L=d_L)
+        # - change cosmology
+        blob = Blob(z=0.1, cosmology=Planck18)
+        d_L = 1.4682341e+27 * u.cm
         assert u.isclose(blob.d_L, d_L, atol=0 * u.cm, rtol=1e-5)
 
     def test_particles_spectra(self):


### PR DESCRIPTION
Hi @jsitarek,

this PR fixes #150.
I took into account your second suggestion, to move the luminosity distance as a last argument.

Then I thought that it would be better _not to allow users to specify the redshift and then an arbitrary distance_, so what I suggest in this PR is to use - instead of `d_L` as last argument - the (`astropy`'s) cosmology to convert the redshift in a distance.

Let me know what do you think, I think the examples in the docs should be working with this approach, as `cosmology` is the last optional argument.

CC @IlariaViale.