### PR TITLE
added pre-commit hooks with isort, black and flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  # https://pycqa.github.io/isort/docs/configuration/black_compatibility.html#integration-with-pre-commit
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        args: ["--profile", "black", "--filter-files"]
+  - repo: https://github.com/psf/black
+    rev: 22.6.0
+    hooks:
+      - id: black
+  # https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html?highlight=other%20tools#flake8
+  - repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+        exclude: experiments
+        args: ["--count", "--max-line-length=100", "--extend-ignore=E203,E712,W503"]

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - pyyaml # needed to read astropy ecsv file
   - matplotlib
   - sherpa
+  - pre-commit
   - pip:
     - agnpy
     - gammapy
-


### PR DESCRIPTION
This PR adds pre-commit hooks.

After installing the [`pre-commit` package](https://pre-commit.com/#install), when the developer commits, the code will be automatically checked for compliance with black and flake8. This should remove the need to run black manually each time, a practice that often introduces formatting changes different for different developers (different black versions used).

The pre-commit config file is copied from gammapy.

A useful tutorial [here](https://ljvmiranda921.github.io/notebook/2018/06/21/precommits-using-black-and-flake8/).