### PR TITLE
Synchrotron losses time evolution

### DIFF
--- a/agnpy/spectra/spectra.py
+++ b/agnpy/spectra/spectra.py
@@ -1,9 +1,11 @@
 # module containing the particle spectra
 import numpy as np
 import astropy.units as u
-from astropy.constants import m_e, m_p
+from astropy.units.quantity import Quantity
+from astropy.constants import m_e, m_p, c
 from scipy.interpolate import CubicSpline
 import matplotlib.pyplot as plt
+import math
 
 
 __all__ = [
@@ -249,6 +251,90 @@ class PowerLaw(ParticleDistribution):
 
     def __call__(self, gamma):
         return self.evaluate(gamma, self.k, self.p, self.gamma_min, self.gamma_max)
+
+    def gamma_values(self):
+        return np.logspace(np.log10(self.gamma_min), np.log10(self.gamma_max), 200)
+
+    def evaluate_time(self, time, energy_loss_function, intervals=1):
+        class Bin:
+            def __init__(self, n, gamma_start, gamma_end):
+                self.n = n
+                self.gamma_start = gamma_start
+                self.gamma_end = gamma_end
+
+        gamma_values = self.gamma_values()
+        n_values = self.__call__(gamma_values)
+        bin_size_sqrt = math.sqrt(gamma_values[1]/gamma_values[0])
+        original_bins = []
+
+        # fill bins with initial data
+        for index, gamma_value in enumerate(gamma_values):
+            n = n_values[index]
+            if index == 0:
+                gamma_start = gamma_value / bin_size_sqrt
+            else:
+                gamma_start = original_bins[index-1].gamma_end
+            original_bins.append(Bin(n, gamma_start, gamma_value * bin_size_sqrt))
+
+        unit_time_interval = time / intervals
+
+        def gamma_recalculated_after_loss(gamma):
+            old_energy = (gamma * m_e * c ** 2).to("J")
+            energy_loss_per_time = energy_loss_function(gamma).to("J s-1")
+            energy_loss = (energy_loss_per_time * unit_time_interval).to("J")
+            new_energy = old_energy - energy_loss
+            if new_energy < 0:
+                raise ValueError(
+                    "Energy loss formula returned value higher then original energy, for gamma " + "{:e}".format(gamma))
+            new_gamma = (new_energy / (m_e * c ** 2)).value
+            return new_gamma
+
+        # move and narrow down the bins according to energy loss function
+        translated_bins = original_bins.copy()
+        for r in range(intervals):
+            for index, bin in enumerate(translated_bins):
+                bin_integral = bin.n * (bin.gamma_end - bin.gamma_start)
+                if index == 0:
+                    new_bin_start = gamma_recalculated_after_loss(bin.gamma_start)
+                else:
+                    new_bin_start = translated_bins[index-1].gamma_end
+                new_bin_end = gamma_recalculated_after_loss(bin.gamma_end)
+                new_bin_width = new_bin_end - new_bin_start
+                if new_bin_width <= 0:
+                    raise ValueError(
+                        "Energy loss formula returned higher energy loss for bin-end than for bin-start;"
+                        " use shorter time intervals to fix it")
+                new_n = bin_integral / (new_bin_width)
+                translated_bins[index] = (Bin(new_n, new_bin_start, new_bin_end))
+
+        # remap the translated bins onto the original gamma points
+        final_bins = []
+        unit = u.Unit("cm-3")
+        for bin in original_bins:
+            final_bins.append(Bin(Quantity(0) * unit, bin.gamma_start, bin.gamma_end))
+        for index, bin in enumerate(final_bins):
+            for translated_bin in translated_bins:
+                gamma_bin_min = bin.gamma_start
+                gamma_bin_max = bin.gamma_end
+                gamma_new_bin_min = translated_bin.gamma_start
+                gamma_new_bin_max = translated_bin.gamma_end
+                if gamma_new_bin_max > gamma_bin_min and gamma_new_bin_min < gamma_bin_max:
+                    if gamma_new_bin_min < gamma_bin_min < gamma_new_bin_max:
+                        overlap = gamma_new_bin_max - gamma_bin_min
+                    elif gamma_new_bin_min < gamma_bin_max < gamma_new_bin_max:
+                        overlap = gamma_bin_max - gamma_new_bin_min
+                    elif gamma_bin_min <= gamma_new_bin_min and gamma_new_bin_max <= gamma_bin_max:
+                        overlap = gamma_new_bin_max - gamma_new_bin_min
+                    else:
+                        raise AssertionError("Unexpected situation, bin has been widened instead of narrowed down")
+                    n = overlap * translated_bin.n
+                    final_bin = final_bins[index]
+                    final_bin.n = final_bin.n + n
+        for bin in final_bins:
+            bin.n = bin.n / (bin.gamma_end - bin.gamma_start)
+
+
+        return gamma_values, np.array(list(map(lambda bin: bin.n.value, final_bins))) * unit
 
     @staticmethod
     def evaluate_SSA_integrand(gamma, k, p, gamma_min, gamma_max):

--- a/agnpy/spectra/tests/test_spectra.py
+++ b/agnpy/spectra/tests/test_spectra.py
@@ -751,7 +751,7 @@ class TestSpectraTimeEvolution:
     @pytest.mark.parametrize("time", [1, 60, 120] * u.s)
     def test_compare_numerical_results_with_analytical_calculation(self, p, time):
         """Test time evolution of spectral electron density for synchrotron energy losses.
-         Use a simple power low spectrum for easy calculation of analytical results."""
+         Use a simple power law spectrum for easy calculation of analytical results."""
         gamma_min = 1e2
         gamma_max = 1e7
         k = 0.1 * u.Unit("cm-3")
@@ -781,7 +781,7 @@ class TestSpectraTimeEvolution:
             rtol=0.05
         )
         assert u.isclose(
-            # only the highest energy range where most losses occur
+            # synchrotron losses are highest at highest energy, so test the highest energy range, as the most affected
             evaluated_n_e.integrate(evaluated_n_e.gamma_max / 10, evaluated_n_e.gamma_max),
             integral_analytical(gamma_before(evaluated_n_e.gamma_max / 10, time), gamma_before(evaluated_n_e.gamma_max, time)),
             rtol=0.05

--- a/agnpy/synchrotron/synchrotron.py
+++ b/agnpy/synchrotron/synchrotron.py
@@ -93,8 +93,8 @@ class Synchrotron(RadiativeProcess):
     def electron_energy_loss_per_time(self, gamma):
         # For synchrotron, energy loss dE/dt formula is:
         # (4/3 * sigma_T * c * magn_energy_dens) * gamma^2
-        # The part in brackets is fixed, so as an improvement we could calculate it once and cache,
-        # and later we could use the formula (fixed * gamma^2)
+        # In case of constant B, the part in brackets is fixed, so as an improvement we could calculate it once
+        # and cache, and later we could use the formula (fixed * gamma^2)
         fixed = self._electron_energy_loss_formula_prefix()
         return (fixed * gamma ** 2).to("erg/s")
 

--- a/agnpy/synchrotron/synchrotron.py
+++ b/agnpy/synchrotron/synchrotron.py
@@ -95,9 +95,12 @@ class Synchrotron(RadiativeProcess):
         # (4/3 * sigma_T * c * magn_energy_dens) * gamma^2
         # The part in brackets is fixed, so as an improvement we could calculate it once and cache,
         # and later we could use the formula (fixed * gamma^2)
-        magn_energy_dens = (self.blob.B.to("T") ** 2) / (2 * mu0)
-        fixed = (4 / 3) * sigma_T * c * magn_energy_dens
+        fixed = self._electron_energy_loss_formula_prefix()
         return (fixed * gamma ** 2).to("erg/s")
+
+    def _electron_energy_loss_formula_prefix(self):
+        magn_energy_dens = (self.blob.B.to("T") ** 2) / (2 * mu0)
+        return (4 / 3) * sigma_T * c * magn_energy_dens
 
     @staticmethod
     def evaluate_tau_ssa(

--- a/agnpy/synchrotron/synchrotron.py
+++ b/agnpy/synchrotron/synchrotron.py
@@ -96,11 +96,12 @@ class Synchrotron(RadiativeProcess):
         # In case of constant B, the part in brackets is fixed, so as an improvement we could calculate it once
         # and cache, and later we could use the formula (fixed * gamma^2)
         fixed = self._electron_energy_loss_formula_prefix()
-        return (fixed * gamma ** 2).to("erg/s")
+        return fixed * gamma ** 2
 
     def _electron_energy_loss_formula_prefix(self):
+        # using SI units here because of the ambiguity of the different CGS systems in terms of mu0 definition
         magn_energy_dens = (self.blob.B.to("T") ** 2) / (2 * mu0)
-        return (4 / 3) * sigma_T * c * magn_energy_dens
+        return ((4 / 3) * sigma_T * c * magn_energy_dens).to("erg/s")
 
     @staticmethod
     def evaluate_tau_ssa(

--- a/agnpy/synchrotron/synchrotron.py
+++ b/agnpy/synchrotron/synchrotron.py
@@ -1,7 +1,7 @@
 # module containing the synchrotron radiative process
 import numpy as np
 import astropy.units as u
-from astropy.constants import e, h, c, m_e, sigma_T
+from astropy.constants import e, h, c, m_e, sigma_T, mu0
 from ..utils.math import axes_reshaper, gamma_e_to_integrate
 from ..utils.conversion import nu_to_epsilon_prime, B_to_cgs, lambda_c_e
 from ..radiative_process import RadiativeProcess
@@ -89,6 +89,15 @@ class Synchrotron(RadiativeProcess):
         self.blob = blob
         self.ssa = ssa
         self.integrator = integrator
+
+    def electron_energy_loss_per_time(self, gamma):
+        # For synchrotron, energy loss dE/dt formula is:
+        # (4/3 * sigma_T * c * magn_energy_dens) * gamma^2
+        # The part in brackets is fixed, so as an improvement we could calculate it once and cache,
+        # and later we could use the formula (fixed * gamma^2)
+        magn_energy_dens = (self.blob.B.to("T") ** 2) / (2 * mu0)
+        fixed = (4 / 3) * sigma_T * c * magn_energy_dens
+        return (fixed * gamma ** 2).to("erg/s")
 
     @staticmethod
     def evaluate_tau_ssa(

--- a/environment.yml
+++ b/environment.yml
@@ -5,15 +5,12 @@ channels:
   - sherpa
 
 dependencies:
-  - python=3.9
-  - pip
-  - numpy>1.20
-  - scipy!=1.10
+  - python>=3.9, <3.12
   - astropy>=5.0, <6.0
+  - numpy>=1.21
+  - scipy>=1.11
   - pyyaml # needed to read astropy ecsv file
   - matplotlib>=3.4
   - sherpa
   - pre-commit
-  - pip:
-    - agnpy
-    - gammapy
+  - gammapy<1.2

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - python>=3.9, <3.12
   - astropy>=5.0, <6.0
   - numpy>=1.21
-  - scipy>=1.11
+  - scipy>=1.5,<1.10
   - pyyaml # needed to read astropy ecsv file
   - matplotlib>=3.4
   - sherpa

--- a/environment.yml
+++ b/environment.yml
@@ -5,8 +5,8 @@ channels:
   - sherpa
 
 dependencies:
-  - python>=3.9, <3.12
-  - astropy>=5.0, <6.0
+  - python>=3.9,<3.12
+  - astropy>=5.0,<6.0
   - numpy>=1.21
   - scipy>=1.5,<1.10
   - pyyaml # needed to read astropy ecsv file

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setuptools.setup(
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
     ],
-    install_requires=["astropy>=5.0, <6.0", "numpy>=1.21", "scipy>=1.11", "pyyaml", "matplotlib>=3.4", "sherpa", "pre-commit", "gammapy<1.2"],
+    install_requires=["astropy>=5.0, <6.0", "numpy>=1.21", "scipy>=1.5,<1.10", "pyyaml", "matplotlib>=3.4", "sherpa", "pre-commit", "gammapy<1.2"],
     python_requires=">=3.9,<3.12",
 )

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setuptools.setup(
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
     ],
-    install_requires=["astropy>=5.0, <6.0", "numpy>=1.21", "scipy>=1.5,<1.10", "pyyaml", "matplotlib>=3.4", "sherpa", "pre-commit", "gammapy<1.2"],
+    install_requires=["astropy>=5.0,<6.0", "numpy>=1.21", "scipy>=1.5,<1.10", "pyyaml", "matplotlib>=3.4", "sherpa", "pre-commit", "gammapy<1.2"],
     python_requires=">=3.9,<3.12",
 )

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setuptools.setup(
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
     ],
-    install_requires=["astropy>=5.0, <6.0", "numpy>=1.21", "scipy>=1.5,!=1.10", "matplotlib>=3.4"],
-    python_requires=">=3.8",
+    install_requires=["astropy>=5.0, <6.0", "numpy>=1.21", "scipy>=1.11", "pyyaml", "matplotlib>=3.4", "sherpa", "pre-commit", "gammapy<1.2"],
+    python_requires=">=3.9,<3.12",
 )


### PR DESCRIPTION
The ParticleDistribution.evaluate_time() function added.
It's a basic method that accepts the energy losses function as the parameter, and evaluates it for the requested time period (with optional subperiods). 
For now  just the first, basic version. It can be later extended to be smarter - for example automatically use shorter time ranges for the energies where higher losses occur.
For now only synchrotron losses implemented, other will be added later.
We can later add the higher level function that would take the flags which radiative processes should be used, instead of accepting generic energy loss function as the parameter.