### PR TITLE
Update readthedocs.yaml config

### DIFF
--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -5,6 +5,12 @@
 # Required
 version: 2
 
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.11"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
@@ -18,7 +24,7 @@ sphinx:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
+  version: 3.11
   install:
     - requirements: docs/requirements.txt
     - method: pip


### PR DESCRIPTION
Current config file was missing the new os build section as said in the error message of the builds.

Also specified in https://docs.readthedocs.io/en/stable/config-file/v2.html

Closes #170 