### PR TITLE
Fix doc snippet about EBL models

### DIFF
--- a/docs/snippets/ebl_models.py
+++ b/docs/snippets/ebl_models.py
@@ -14,7 +14,9 @@ E = nu.to("TeV", equivalencies=u.spectral())
 
 for model in ["franceschini", "dominguez", "finke", "saldana-lopez"]:
     ebl = EBL(model)
-    absorption = ebl.absorption(nu, z)
+    absorption = ebl.absorption(
+        nu, z
+    )  # warning: in agnpy <= v0.4.0 the arguments order is reversed!
     plt.loglog(E, absorption, label=model)
 
 plt.xlabel(r"$E\,/\,{\rm TeV}$")


### PR DESCRIPTION
The arguments for `ebl.absorption` were switched.

To overcome such issues you should:

- test you documentation snippets (https://www.sphinx-doc.org/en/master/usage/extensions/doctest.html)
- add static typing (https://mypy.readthedocs.io/en/stable/)