### PR TITLE
Ver 0.5.1

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -79,5 +79,5 @@
     ],
     "title": "agnpy",
     "upload_type": "software",
-    "version": "0.5.0"
+    "version": "0.5.1"
 }

--- a/agnpy/fit/__init__.py
+++ b/agnpy/fit/__init__.py
@@ -1,10 +1,2 @@
-import logging
-
-logger = logging.getLogger(__name__)
-
-try:
-    from .models import *
-    from .data import *
-except ImportError:
-    logger.warning("sherpa and gammapy are not installed, the agnpy.fit module cannot be used")
-    pass
+from .models import *
+from .data import *

--- a/agnpy/fit/core.py
+++ b/agnpy/fit/core.py
@@ -1,7 +1,5 @@
 # functions / classes shared by all wrapper types
 import numpy as np
-from sherpa.models import model
-from gammapy import modeling
 from ..spectra import InterpolatedDistribution
 
 
@@ -25,6 +23,8 @@ class Parameter:
         modelname : str
             The name of the model component containing the parameter.
         """
+        from sherpa.models import model # lazy loaded import - don't move it to the top of the file!
+
         # sherpa has a hard_max set to
         hard_max = 3.40282e38
         if self.max > hard_max:
@@ -42,6 +42,8 @@ class Parameter:
 
     def to_gammapy_parameter(self):
         """Return a `~gammapy.modeling.parameter."""
+        from gammapy import modeling # lazy loaded import - don't move it to the top of the file!
+
         return modeling.Parameter(
             name=self.name,
             value=self.value,

--- a/agnpy/fit/data.py
+++ b/agnpy/fit/data.py
@@ -1,9 +1,5 @@
 import numpy as np
-import astropy.units as u
 from astropy.table import Table
-from sherpa.data import Data1D
-from gammapy.estimators import FluxPoints
-from gammapy.datasets import FluxPointsDataset, Datasets
 
 
 def load_sherpa_flux_points(sed_path, E_min, E_max, systematics_dict=None):
@@ -30,6 +26,8 @@ def load_sherpa_flux_points(sed_path, E_min, E_max, systematics_dict=None):
     -------
     `~sherpa.data.Data1D`
     """
+    from sherpa.data import Data1D # lazy loaded import - don't move it to the top of the file!
+
     table = Table.read(sed_path)
     table = table.group_by("instrument")
 
@@ -111,6 +109,9 @@ def load_gammapy_flux_points(sed_path, E_min, E_max, systematics_dict=None):
     -------
     `~gammapy.dataset.Datasets`, list of flux points datasets
     """
+    from gammapy.estimators import FluxPoints # lazy loaded imports - don't move them to the top of the file!
+    from gammapy.datasets import FluxPointsDataset, Datasets
+
     datasets = Datasets()
 
     table = Table.read(sed_path)

--- a/agnpy/fit/models.py
+++ b/agnpy/fit/models.py
@@ -1,20 +1,24 @@
-from .gammapy_wrapper import (
-    SynchrotronSelfComptonSpectralModel,
-    ExternalComptonSpectralModel,
-)
-from .sherpa_wrapper import (
-    SynchrotronSelfComptonRegriddableModel1D,
-    ExternalComptonRegriddableModel1D,
-)
-
-
 class SynchrotronSelfComptonModel:
     """Model for synchrotron self-Compton scenario."""
 
     def __new__(cls, n_e, ssa=False, backend="gammapy"):
         if backend == "sherpa":
+            try:
+                from .sherpa_wrapper import SynchrotronSelfComptonRegriddableModel1D
+            except ImportError:
+                raise ImportError(
+                    "sherpa is required to use the sherpa backend, "
+                    "install it with: pip install sherpa"
+                )
             return SynchrotronSelfComptonRegriddableModel1D(n_e, ssa)
         elif backend == "gammapy":
+            try:
+                from .gammapy_wrapper import SynchrotronSelfComptonSpectralModel
+            except ImportError:
+                raise ImportError(
+                    "gammapy is required to use the gammapy backend, "
+                    "install it with: pip install gammapy"
+                )
             return SynchrotronSelfComptonSpectralModel(n_e, ssa)
         else:
             raise ValueError(
@@ -27,8 +31,22 @@ class ExternalComptonModel:
 
     def __new__(cls, n_e, targets, ssa=False, backend="gammapy"):
         if backend == "sherpa":
+            try:
+                from .sherpa_wrapper import ExternalComptonRegriddableModel1D
+            except ImportError:
+                raise ImportError(
+                    "sherpa is required to use the sherpa backend, "
+                    "install it with: pip install sherpa"
+                )
             return ExternalComptonRegriddableModel1D(n_e, targets, ssa)
         elif backend == "gammapy":
+            try:
+                from .gammapy_wrapper import ExternalComptonSpectralModel
+            except ImportError:
+                raise ImportError(
+                    "gammapy is required to use the gammapy backend, "
+                    "install it with: pip install gammapy"
+                )
             return ExternalComptonSpectralModel(n_e, targets, ssa)
         else:
             raise ValueError(

--- a/agnpy/time_evolution/_time_evolution_utils.py
+++ b/agnpy/time_evolution/_time_evolution_utils.py
@@ -1,7 +1,6 @@
 import numpy as np
 from astropy.units import Quantity, Unit
 from numpy._typing import NDArray
-from pygments.styles import vs
 from astropy.constants import m_e, c, h, e
 from agnpy import InterpolatedDistribution, EmptyDistribution
 from agnpy.time_evolution.types import BinsWithDensities, FnParams, TimeEvaluationResult, GammaFn, SubgroupsList

--- a/agnpy/time_evolution/_time_evolution_utils.py
+++ b/agnpy/time_evolution/_time_evolution_utils.py
@@ -3,18 +3,12 @@ from astropy.units import Quantity, Unit
 from numpy._typing import NDArray
 from astropy.constants import m_e, c, h, e
 from agnpy import InterpolatedDistribution, EmptyDistribution
-from agnpy.time_evolution.types import BinsWithDensities, FnParams, TimeEvaluationResult, GammaFn, SubgroupsList
+from agnpy.time_evolution.types import BinsWithDensities, FnParams, TimeEvaluationResult, GammaFn, SubgroupsList, DistributionToSinglePointCollapseError
 from agnpy.utils.conversion import mec2
 from scipy.interpolate import PchipInterpolator
 from typing import Tuple
 
 bin_size_factor = 1e-4
-
-class DistributionToSinglePointCollapseError(Exception):
-    def __init__(self, gamma_point):
-        self.gamma_point = gamma_point
-        super().__init__(f"Unsupported state, cannot create InterpolatedDistribution - distribution collapsed to a single gamma point {gamma_point}")
-
 
 def update_bin_ub(gm_bins, mask = None):
     """ Update bin upper bounds, but only for bins indicated by the mask

--- a/agnpy/time_evolution/types.py
+++ b/agnpy/time_evolution/types.py
@@ -23,6 +23,11 @@ class TimeEvaluationResult(NamedTuple):
     rel_inj_rates: dict[str, Quantity]
     abs_inj_rates: dict[str, Quantity]
 
+class DistributionToSinglePointCollapseError(Exception):
+    def __init__(self, gamma_point):
+        self.gamma_point = gamma_point
+        super().__init__(f"Unsupported state, cannot create InterpolatedDistribution - distribution collapsed to a single gamma point {gamma_point}")
+
 GammaFn = Callable[[FnParams], Quantity]
 """ 
 An abstract function that, for given gamma values provided in FnParams (and optionally densities), calculates a new

--- a/codemeta.json
+++ b/codemeta.json
@@ -7,9 +7,9 @@
     "dateModified": "2023-02-12",
     "codeRepository": "https://github.com/cosimoNigro/agnpy",
     "issueTracker": "https://github.com/cosimoNigro/agnpy/issues",
-    "downloadUrl": "https://github.com/cosimoNigro/agnpy/releases/tag/v0.5.0",
+    "downloadUrl": "https://github.com/cosimoNigro/agnpy/releases/tag/v0.5.1",
     "name": "agnpy",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "identifier": "10.5281/zenodo.4055175",
     "description": "agnpy is a python package focusing on the computation of the radiative processes of relativistic particles accelerated in the jets of Active Galactic Nuclei (AGN). It includes classes describing the galaxy components responsible for line and thermal emission and calculates the absorption due to gamma-gamma pair production on soft (IR-UV) photon fields.",
     "applicationCategory": "Astronomy",
@@ -18,7 +18,7 @@
     "isPartOf": "https://www.astropy.org/affiliated/",
     "referencePublication": "https://doi.org/10.1051/0004-6361/202142000",
     "readme": "https://agnpy.readthedocs.io/en/latest/",
-    "softwareVersion": "0.5.0",
+    "softwareVersion": "0.5.1",
     "funder": {
         "@type": "Organization",
         "name": "European Union's Horizon 2020 research and innovation programme"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = "2025, agnpy developers"
 author = "agnpy developers"
 
 # The full version, including alpha/beta/rc tags
-release = "0.5.0"
+release = "0.5.1"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,13 @@ dependencies = [
     "scipy>=1.14",
     "pyyaml>=6.0", # needed to read astropy ecsv file
     "matplotlib>=3.9.1",
-    "sherpa",
     "pre-commit",
-    "gammapy>=1.3",
 ]
+
+[project.optional-dependencies]
+gammapy = ["gammapy>=1.3"]
+sherpa = ["sherpa"]
+all = ["agnpy[gammapy]", "agnpy[sherpa]"]
 
 [project.urls]
 Homepage = "https://github.com/cosimoNigro/agnpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agnpy"
-version = "0.5.0"
+version = "0.5.1"
 description = "Modelling jetted Active Galactic Nuclei radiative processes with python"
 readme = { file = "README.md", content-type = "text/markdown" }
 authors = [


### PR DESCRIPTION
I prepared version 0.5.1. 

It's purely the bug-fix relase, for 3 bugs related to project dependencies:

- in version 0.5.0 there was a faulty "import pygments.styles" added by mistake in the timeevolution python file, making the timeevolution code failing if you didn't have this dependency installed (and this dependency is not really used by agnpy)
- version 0.5.0 required both gammapy and sherpa to be installed if you want to use any of the fitting wrappers, which is not correct - you should not need sherpa if you only use gammapy wrapper, and vice-versa.
-  class DistributionToSinglePointCollapseError should be public, so should be in agnpy.time_evolution.types instead of agnpy.time_evolution._time_evolution_utils

These 3 problems are fixed in 0.5.1