### PR TITLE
A small fix to prevent interpolation crashes in some very rare cases + project dependencies fix + fixed swapped params

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest pytest-cov
-        python -m pip install -e . --config-settings editable_mode=compat
-        python -m pip install gammapy
-        python -m pip install sherpa
+        python -m pip install -e ".[all]" --config-settings editable_mode=compat
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/agnpy/time_evolution/_time_evolution_utils.py
+++ b/agnpy/time_evolution/_time_evolution_utils.py
@@ -196,10 +196,16 @@ def merge_points(x, y, merge_groups, interpolated_distribution):
     - x_new, y_new: arrays with merged points
     """
 
+    def merge_func(x_points):
+        if x_points[0] == x_points[-1]: # if all points are the same, just return the first one (they are sorted so just compare first to last)
+            return x_points[0]
+        else: # else calculate the average
+            return np.power(10, np.mean(np.log10(x_points)))
+
     labels = np.full(len(x), -1)
     for g_idx, group in enumerate(merge_groups):
         labels[group] = g_idx
-    x_means = np.array([np.exp(np.mean(np.log(x[labels == g]))) for g in range(len(merge_groups))])
+    x_means = np.array([merge_func(x[labels == g]) for g in range(len(merge_groups))])
     if interpolated_distribution is None:
         y_means = Quantity([np.mean(y[labels == g]) for g in range(len(merge_groups))])
     else:

--- a/agnpy/time_evolution/time_evolution.py
+++ b/agnpy/time_evolution/time_evolution.py
@@ -270,8 +270,8 @@ class TimeEvolution:
             total_time_elapsed += step_time
             if self._distribution_change_callback is not None:
                 self._distribution_change_callback(TimeEvaluationResult(total_time_elapsed,
-                    gm_bins[0], density, subgroups_density, energy_changes_lb(en_chg_rates), abs_injection_rates,
-                    rel_injection_rates))
+                    gm_bins[0], density, subgroups_density, energy_changes_lb(en_chg_rates), rel_injection_rates,
+                    abs_injection_rates))
             progress_percent = int((100 * total_time_elapsed / self._total_time_sec).round(0))
             log.info("Progress: %3d%% %s (%i bins)", progress_percent, total_time_elapsed, gm_bins.shape[-1])
 

--- a/agnpy/time_evolution/time_evolution.py
+++ b/agnpy/time_evolution/time_evolution.py
@@ -421,12 +421,12 @@ class TimeEvolution:
         return en_chg_rates_grouped, rel_injection_rates_grouped, abs_injection_rates_grouped
 
     def _sort_and_merge_bins(self, gm_bins, densities, interpolated_distribution):
-        gm_bins, densities, mapping_deduplication = sort_and_merge_duplicates(gm_bins, densities, interpolated_distribution)
+        gm_bins_sorted, densities_sorted, mapping_deduplication = sort_and_merge_duplicates(gm_bins, densities, interpolated_distribution)
         if self._merge_bins_closer_than is None:
-            return gm_bins, densities, mapping_deduplication
-        gm_bins, densities, mapping_too_close = self._remove_too_close_bins(gm_bins, densities, interpolated_distribution)
+            return gm_bins_sorted, densities_sorted, mapping_deduplication
+        gm_bins_sorted_and_merged, densities_sorted_and_merged, mapping_too_close = self._remove_too_close_bins(gm_bins_sorted, densities_sorted, interpolated_distribution)
         additional_mapping = combine_mapping(mapping_deduplication, mapping_too_close)
-        return gm_bins, densities, additional_mapping
+        return gm_bins_sorted_and_merged, densities_sorted_and_merged, additional_mapping
 
     def _remove_gamma_beyond_bounds(self, gm_bins):
         gm_bins_lb = gm_bins[0]
@@ -438,8 +438,8 @@ class TimeEvolution:
             return gm_bins[..., mapping], mapping
         return gm_bins, initial
 
-    def _remove_too_close_bins(self, gm_bins, densities, interpolated_distribution):
-        gm_bins_lb_log = np.log10(gm_bins[0])
+    def _remove_too_close_bins(self, gm_bins_sorted, densities, interpolated_distribution):
+        gm_bins_lb_log = np.log10(gm_bins_sorted[0])
         gaps = np.diff(gm_bins_lb_log)
         too_close_bins_mask = gaps < self._merge_bins_closer_than
         # don't merge first and last bin
@@ -450,12 +450,12 @@ class TimeEvolution:
             keep_idx = np.setdiff1d(np.arange(len(densities)), close_bins_idx, assume_unique=True)
             close_bins_groups = group_duplicates(close_bins_idx)
             log.info("Merging groups of bins %s", close_bins_groups)
-            gm_bins_lb_merged, densities_merged = merge_points(gm_bins[0], densities, close_bins_groups,
+            gm_bins_lb_merged, densities_merged = merge_points(gm_bins_sorted[0], densities, close_bins_groups,
                                                                interpolated_distribution)
             groups_start_idx = [lst[0] for lst in close_bins_groups]
-            groups_start_mask = np.isin(np.arange(gm_bins.shape[1]), groups_start_idx)
-            gm_bins_ub_merged = gm_bins[1][keep_idx]
+            groups_start_mask = np.isin(np.arange(gm_bins_sorted.shape[1]), groups_start_idx)
+            gm_bins_ub_merged = gm_bins_sorted[1][keep_idx]
             gm_bins_ub_merged[groups_start_mask[keep_idx]] = 0
             return np.array([gm_bins_lb_merged, gm_bins_ub_merged]), densities_merged, keep_idx
         else:
-            return gm_bins, densities, np.arange(gm_bins.shape[-1])
+            return gm_bins_sorted, densities, np.arange(gm_bins_sorted.shape[-1])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,14 +23,14 @@ dependencies = [
     "astropy>=7.0",
     "numpy>=1.24,<2.3",
     "pandas>=1.5",
-    "scipy>=1.14",
+    "scipy>=1.14,<1.18",
     "pyyaml>=6.0", # needed to read astropy ecsv file
     "matplotlib>=3.9.1",
     "pre-commit",
 ]
 
 [project.optional-dependencies]
-gammapy = ["gammapy>=1.3"]
+gammapy = ["gammapy>=1.3", "regions<0.11"] # gammapy-2.1 not compatible with regions 0.11+
 sherpa = ["sherpa"]
 all = ["agnpy[gammapy]", "agnpy[sherpa]"]
 


### PR DESCRIPTION
1. A small fix to a special situation when calculating average of equal gamma points returns a different value, which may cause interpolation crashing in some corner-cases.
2. Fix in the project dependencies (added constraints to prevent failures from the unsupported latest versions of dependencies)
3. Fixed swapped parameters